### PR TITLE
Removed dead code or discovered uncovered code in test suite

### DIFF
--- a/lib/seg.rb
+++ b/lib/seg.rb
@@ -29,10 +29,6 @@ class Seg
     @pos = 1
   end
 
-  def head
-    @path[@pos]
-  end
-
   def curr
     @path[@pos - 1, @size]
   end

--- a/test/all.rb
+++ b/test/all.rb
@@ -5,6 +5,10 @@ test "consume" do
   assert_equal segment.prev, ""
   assert_equal segment.curr, "/foo/bar/baz"
 
+  assert_equal segment.consume("fo"), false
+  assert_equal segment.prev, ""
+  assert_equal segment.curr, "/foo/bar/baz"
+
   assert_equal segment.consume("foo"), true
   assert_equal segment.prev, "/foo"
   assert_equal segment.curr, "/bar/baz"

--- a/test/all.rb
+++ b/test/all.rb
@@ -4,26 +4,32 @@ test "consume" do
   assert_equal segment.consume("bar"), false
   assert_equal segment.prev, ""
   assert_equal segment.curr, "/foo/bar/baz"
+  assert !segment.root?
 
   assert_equal segment.consume("fo"), false
   assert_equal segment.prev, ""
   assert_equal segment.curr, "/foo/bar/baz"
+  assert !segment.root?
 
   assert_equal segment.consume("foo"), true
   assert_equal segment.prev, "/foo"
   assert_equal segment.curr, "/bar/baz"
+  assert !segment.root?
 
   assert_equal segment.consume("foo"), false
   assert_equal segment.prev, "/foo"
   assert_equal segment.curr, "/bar/baz"
+  assert !segment.root?
 
   assert_equal segment.consume("bar/baz"), true
   assert_equal segment.prev, "/foo/bar/baz"
   assert_equal segment.curr, ""
+  assert segment.root?
 
   assert_equal segment.consume("baz"), false
   assert_equal segment.prev, "/foo/bar/baz"
   assert_equal segment.curr, ""
+  assert segment.root?
 end
 
 test "capture" do
@@ -34,18 +40,22 @@ test "capture" do
   assert_equal segment.capture(:c1, captures), true
   assert_equal segment.prev, "/foo"
   assert_equal segment.curr, "/bar/baz"
+  assert !segment.root?
 
   assert_equal segment.capture(:c2, captures), true
   assert_equal segment.prev, "/foo/bar"
   assert_equal segment.curr, "/baz"
+  assert !segment.root?
 
   assert_equal segment.capture(:c3, captures), true
   assert_equal segment.prev, "/foo/bar/baz"
   assert_equal segment.curr, ""
+  assert segment.root?
 
   assert_equal segment.capture(:c4, captures), false
   assert_equal segment.prev, "/foo/bar/baz"
   assert_equal segment.curr, ""
+  assert segment.root?
 
   assert_equal "foo", captures[:c1]
   assert_equal "bar", captures[:c2]

--- a/test/all.rb
+++ b/test/all.rb
@@ -17,11 +17,7 @@ test "consume" do
   assert_equal segment.prev, "/foo"
   assert_equal segment.curr, "/bar/baz"
 
-  assert_equal segment.consume("bar"), true
-  assert_equal segment.prev, "/foo/bar"
-  assert_equal segment.curr, "/baz"
-
-  assert_equal segment.consume("baz"), true
+  assert_equal segment.consume("bar/baz"), true
   assert_equal segment.prev, "/foo/bar/baz"
   assert_equal segment.curr, ""
 


### PR DESCRIPTION
I was looking at the code for seg, and was a little confused by this:

``` ruby
case find(len)
when nil, SLASH
  # ...
else
  return false
end
```

It checks if the next character is either a `/` or a `nil`. I'm not sure when it could ever be anything else, so I removed this from the code (and the `find` method, as it is only used here). I ran the test suite again and the test suite is still green.

So I'm wondering what the code is for. Either it is dead code, then it can be removed. Or it covers some case I don't understand, then it has to be covered by a test :smile: 
